### PR TITLE
:bug: 各サービスごとの金額情報が出るように

### DIFF
--- a/lambda_function.rb
+++ b/lambda_function.rb
@@ -53,8 +53,8 @@ end
 def summerize_cost_groups(cost_groups, rate)
   sum = 0
   formatted_cost_groups = cost_groups.map do |group|
-    amount = group.dig(:metrics, 'AmortizedCost', :amount).to_f
-    sum += amount * rate
+    amount = group.dig(:metrics, 'AmortizedCost', :amount).to_f * rate
+    sum += amount
     "#{group.dig(:keys, 0)} : #{round(amount)}円"
   end
 


### PR DESCRIPTION
## 概要

合計金額は出るが、各サービスの金額が出なくなった。
![CleanShot 2023-01-07 at 11 09 00](https://user-images.githubusercontent.com/71323834/211126766-c04d279c-c2d7-4541-996e-dcf290c87f1b.png)


## 原因
- 以下のリファクタを行った結果
 - https://github.com/keisukesaito7/aws_cost_notify_ruby/pull/8/files#diff-aeee967612513fe2ec1dc94fe494e7c30c23f6a11b5ae9b7149676351b31523eL55-L59
- USD のまま round してしまっていたため、0 に丸め込まれてしまった

## 結果

![CleanShot 2023-01-07 at 11 08 43](https://user-images.githubusercontent.com/71323834/211126756-5f584e26-2235-4819-8698-e22c9172f659.png)
